### PR TITLE
fix bug where first table repeated

### DIFF
--- a/api/report.py
+++ b/api/report.py
@@ -127,7 +127,7 @@ def create_report(unit_id, path, config):
 
                         create_table(
                             doc,
-                            ecosystem["indicators"][0]["table"]["indicator_table"],
+                            indicator["table"]["indicator_table"],
                             caption,
                         )
 


### PR DESCRIPTION
All indicators for an ecosystem showed the same table (the first indicator's table). Fixed it.